### PR TITLE
Support for PCM

### DIFF
--- a/tts.go
+++ b/tts.go
@@ -13,6 +13,7 @@ const api = "https://polly.us-west-2.amazonaws.com"
 const (
 	MP3 format = iota
 	OGG
+	PCM
 )
 
 const (
@@ -111,6 +112,8 @@ func (tts *TTS) Format(format format) {
 		tts.request.OutputFormat = "mp3"
 	case OGG:
 		tts.request.OutputFormat = "ogg_vorbis"
+	case PCM:
+		tts.request.OutputFormat = "pcm"
 	}
 }
 


### PR DESCRIPTION
I added support for PCM

```
https://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html

OutputFormat
The format in which the returned output will be encoded. For audio stream, this will be mp3, ogg_vorbis, or pcm. For speech marks, this will be json.

When pcm is used, the content returned is audio/pcm in a signed 16-bit, 1 channel (mono), little-endian format.

Type: String

Valid Values: json | mp3 | ogg_vorbis | pcm

Required: Yes
```